### PR TITLE
Open versus merged GIT to use a fixed number of images

### DIFF
--- a/cmd/ovm/download_recent.go
+++ b/cmd/ovm/download_recent.go
@@ -5,22 +5,20 @@ import (
 	"image"
 	"image/png"
 	"strings"
-	"time"
 
 	"github.com/prince-chrismc/conan-center-index-pending-review/v2/internal"
-	"github.com/prince-chrismc/conan-center-index-pending-review/v2/internal/duration"
 	"github.com/prince-chrismc/conan-center-index-pending-review/v2/pkg/pending_review"
 )
 
+// GetOvmPngFromThisWeek returns the last sevent PNGs that have been uploaded.
+// Note: This is under the basis that the deployment does this every ~24hrs.
 func GetOvmPngFromThisWeek(context context.Context, client *pending_review.Client) ([]image.Image, error) {
-	window := time.Now().Truncate(duration.WEEK)
-
-	commits, err := internal.GetCommitsSince(context, client, "open-versus-merged.png", window)
+	commits, err := internal.GetCommits(context, client, "open-versus-merged.png", 7)
 	if err != nil {
 		return nil, err
 	}
 
-	snapshots := make([]image.Image, 0)
+	snapshots := make([]image.Image, 0, 7)
 
 	for _, commit := range commits {
 		fileContent, err := internal.GetDataFileAtRef(context, client, "open-versus-merged.png", commit.GetSHA())

--- a/cmd/ovm/dry_run.go
+++ b/cmd/ovm/dry_run.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"image"
 	"image/gif"
-	"image/png"
 	"os"
 
 	"github.com/prince-chrismc/conan-center-index-pending-review/v2/internal/charts"
@@ -29,13 +28,8 @@ func SaveToDisk(barGraph chart.StackedBarChart, images []image.Image) error {
 		return err
 	}
 
-	img, err := png.Decode(&b)
-	if err != nil {
-		fmt.Printf("Problem decoding %s %v\n", "ovm.png", err)
-		return err
-	}
-
-	images = append([]image.Image{img}, images...)
+	// TODO(prince-chrismc) Fix graph PNG Decode
+	// Dont bother with graph results since they are oddly sized
 	jif := charts.MakeGif(images, delay)
 
 	g, _ := os.Create("ovm.gif")

--- a/cmd/ovm/opened_versus_merged.go
+++ b/cmd/ovm/opened_versus_merged.go
@@ -53,13 +53,10 @@ func OpenVersusMerged(token string, dryRun bool) error {
 	countOpenedPullRequests(context, client, opw)
 
 	images, err := GetOvmPngFromThisWeek(context, client)
-	if err != nil {
+	if err != nil || len(images) == 0 { // We know there should always be commits
 		fmt.Printf("Problem getting %s history %v\n", "ovm.png", err)
 		os.Exit(1)
 	}
-
-	// TODO(prince-chrismc) The last one is placed weirdly...
-	images = images[:len(images)-1]
 
 	fmt.Println("::endgroup")
 

--- a/internal/commit.go
+++ b/internal/commit.go
@@ -11,7 +11,18 @@ import (
 	"github.com/prince-chrismc/conan-center-index-pending-review/v2/pkg/pending_review"
 )
 
-// GetCommitsSince returns a list of commits made to a certain file after a point in time from the raw-data branch
+// GetCommits returns a list of of number from the raw-data branch
+func GetCommits(context context.Context, client *pending_review.Client, file string, count int) ([]*github.RepositoryCommit, error) {
+	commits, _, err := client.Repositories.ListCommits(context, "prince-chrismc", "conan-center-index-pending-review",
+		&github.CommitsListOptions{SHA: "raw-data", Path: file, ListOptions: github.ListOptions{PerPage: count}})
+	if err != nil {
+		return nil, err
+	}
+
+	return commits, nil
+}
+
+// Deprecated: GetCommitsSince returns a list of commits made to a certain file after a point in time from the raw-data branch
 func GetCommitsSince(context context.Context, client *pending_review.Client, file string, since time.Time) ([]*github.RepositoryCommit, error) {
 	commits, _, err := client.Repositories.ListCommits(context, "prince-chrismc", "conan-center-index-pending-review",
 		&github.CommitsListOptions{SHA: "raw-data", Path: file, Since: since})


### PR DESCRIPTION
 switching from time to fix number of frames to use when creating the GIF

resolves #36 the number should always be less then 1 MB since everything is fixed sized 
resolves #37 there's already 100s of commits so the fixed number is less... there's no temporal factor to break things