### PR TITLE
Modifing links to PRs to not create references in those PRs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,11 +26,6 @@ jobs:
         with:
           go-version: ^1.19
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
       - run: go get -v -t -d ./...
 
       - run: go test -race -coverprofile=coverage.out -covermode=atomic -v ./...
@@ -58,11 +53,6 @@ jobs:
         with:
           go-version: ^1.19
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
       - run: go get -v -t -d ./...
 
       - run: go run ./cmd/cpr -t ${{ secrets.REPO_PAT }} -i ${{ vars.ISSUE_NUMBER }}

--- a/internal/format/reviews.go
+++ b/internal/format/reviews.go
@@ -28,6 +28,11 @@ func ReviewsToMarkdownRows(prs []*pending_review.PullRequestSummary, canMerge bo
 	return retval, count
 }
 
+// https://github.com/orgs/community/discussions/23123#discussioncomment-3239240
+func replaceGithubURL(input string) string {
+    return strings.Replace(input, "https://github.com", "https://www.github.com", 1)
+}
+
 func underWay(pr *pending_review.PullRequestSummary) string {
 	var retval string
 	title := title(pr.Change, pr.Recipe)
@@ -37,7 +42,7 @@ func underWay(pr *pending_review.PullRequestSummary) string {
 	}
 
 	columns := []string{
-		fmt.Sprint("[#", pr.Number, "](", pr.ReviewURL, ")"),
+		fmt.Sprint("[#", pr.Number, "](", replaceGithubURL(pr.ReviewURL), ")"),
 		fmt.Sprint("[", pr.OpenedBy, "](https://github.com/", pr.OpenedBy, ")"),
 		pr.CreatedAt.Format("Jan 2"),
 		title,
@@ -65,7 +70,7 @@ func toMerge(pr *pending_review.PullRequestSummary) string {
 	}
 
 	columns := []string{
-		fmt.Sprint("[#", pr.Number, "](", pr.ReviewURL, ")"),
+		fmt.Sprint("[#", pr.Number, "](", replaceGithubURL(pr.ReviewURL), ")"),
 		fmt.Sprint("[", pr.OpenedBy, "](https://github.com/", pr.OpenedBy, ")"),
 		pr.CreatedAt.Format("Jan 2"),
 		title,

--- a/internal/format/reviews_test.go
+++ b/internal/format/reviews_test.go
@@ -68,11 +68,11 @@ func TestFormatMarkdownRows(t *testing.T) {
 
 	mergeRow, mergeCount := ReviewsToMarkdownRows(rs, true)
 	assert.Equal(t, mergeCount, 1)
-	assert.Equal(t, "[#4356](https://github.com/conan-io/conan-center-index/pull/4356)|[prince-chrismc](https://github.com/prince-chrismc)|Jan 25|:memo: paho-mqtt-c|15|madebr, **SSE4**, SpaceIm\n", mergeRow)
+	assert.Equal(t, "[#4356](https://www.github.com/conan-io/conan-center-index/pull/4356)|[prince-chrismc](https://github.com/prince-chrismc)|Jan 25|:memo: paho-mqtt-c|15|madebr, **SSE4**, SpaceIm\n", mergeRow)
 
 	reviewRow, reviewCount := ReviewsToMarkdownRows(rs, false)
 	assert.Equal(t, reviewCount, 1)
-	assert.Equal(t, "[#4556](https://github.com/conan-io/conan-center-index/pull/4556)|[anton-danielsson](https://github.com/anton-danielsson)|Jan 1|:memo: protobuf|:green_circle: XS|36|Apr 9 :bell:|uilianries|prince-chrismc\n", reviewRow)
+	assert.Equal(t, "[#4556](https://www.github.com/conan-io/conan-center-index/pull/4556)|[anton-danielsson](https://github.com/anton-danielsson)|Jan 1|:memo: protobuf|:green_circle: XS|36|Apr 9 :bell:|uilianries|prince-chrismc\n", reviewRow)
 }
 
 func TestFormatMarkdownRowsDocs(t *testing.T) {
@@ -108,7 +108,7 @@ func TestFormatMarkdownRowsDocs(t *testing.T) {
 
 	mergeRow, mergeCount := ReviewsToMarkdownRows(rs, true)
 	assert.Equal(t, mergeCount, 1)
-	assert.Equal(t, "[#7648](https://github.com/conan-io/conan-center-index/pull/7648)|[jgsogo](https://github.com/jgsogo)|Oct 11|:green_book: docs|3|**uilianries**, SSE4, prince-chrismc\n", mergeRow)
+	assert.Equal(t, "[#7648](https://www.github.com/conan-io/conan-center-index/pull/7648)|[jgsogo](https://github.com/jgsogo)|Oct 11|:green_book: docs|3|**uilianries**, SSE4, prince-chrismc\n", mergeRow)
 }
 
 func TestFormatMarkdownRowsCiPending(t *testing.T) {
@@ -141,7 +141,7 @@ func TestFormatMarkdownRowsCiPending(t *testing.T) {
 
 	mergeRow, mergeCount := ReviewsToMarkdownRows(rs, false)
 	assert.Equal(t, mergeCount, 1)
-	assert.Equal(t, "[#8557](https://github.com/conan-io/conan-center-index/pull/8557)|[daravi](https://github.com/daravi)|Dec 28|:stopwatch: libkmod|???|0|:eyes:||\n", mergeRow)
+	assert.Equal(t, "[#8557](https://www.github.com/conan-io/conan-center-index/pull/8557)|[daravi](https://github.com/daravi)|Dec 28|:stopwatch: libkmod|???|0|:eyes:||\n", mergeRow)
 }
 
 func TestFormatMarkdownRowsCiSuccess(t *testing.T) {
@@ -174,5 +174,5 @@ func TestFormatMarkdownRowsCiSuccess(t *testing.T) {
 
 	mergeRow, mergeCount := ReviewsToMarkdownRows(rs, false)
 	assert.Equal(t, mergeCount, 1)
-	assert.Equal(t, "[#8557](https://github.com/conan-io/conan-center-index/pull/8557)|[daravi](https://github.com/daravi)|Dec 28|:new: libkmod|M|0|:eyes:||\n", mergeRow)
+	assert.Equal(t, "[#8557](https://www.github.com/conan-io/conan-center-index/pull/8557)|[daravi](https://github.com/daravi)|Dec 28|:new: libkmod|M|0|:eyes:||\n", mergeRow)
 }


### PR DESCRIPTION
This uses a trick described here: https://github.com/orgs/community/discussions/23123#discussioncomment-3239240 to not create references in those linked pull requests.

Regularly, GitHub creates references in issues and pull requests if they are linked from other issues and pull requests anywhere on GitHub.

This addresses some concerns in https://github.com/conan-io/conan-center-index/pull/24165 that some bots cause confusion in CCI PRs. I personally don't share this point of view when it comes to references, but it is easy to fix.

Additionally, this PR disables CI caching which was broken for a while. I don't know why it was broken, but it doesn't really seem necessary as CI is pretty fast anyway.
